### PR TITLE
SEO changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-dsnp-org",
-  "description": "DSNP.org is a non-profit organization supporting the Decentralized Social Network Protocol (DSNP)",
+  "description": "DSNP.org is a non-profit organization supporting the Decentralized Social Networking Protocol (DSNP)",
   "homepage": "https://www.dsnp.org",
   "version": "1.0.0",
   "license": "MIT",
@@ -46,7 +46,7 @@
     "cheerio": "1.0.0-rc.5",
     "gatsby": "3.7.2",
     "gatsby-awesome-pagination": "^0.3.8",
-    "gatsby-cli": "^3.7.1",
+    "gatsby-cli": "^3.9.0",
     "gatsby-plugin-advanced-sitemap": "2.0.0",
     "gatsby-plugin-catch-links": "3.7.1",
     "gatsby-plugin-feed": "3.7.1",

--- a/src/components/common/meta/ArticleMeta.js
+++ b/src/components/common/meta/ArticleMeta.js
@@ -51,7 +51,7 @@ const ArticleMetaGhost = ({ data, settings, canonical }) => {
                 height: 60,
             },
         },
-        description: ghostPost.meta_description || ghostPost.excerpt,
+        description: ghostPost.meta_description || "",
         mainEntityOfPage: {
             "@type": `WebPage`,
             "@id": config.siteUrl,
@@ -62,7 +62,7 @@ const ArticleMetaGhost = ({ data, settings, canonical }) => {
         <>
             <Helmet>
                 <title>{ghostPost.meta_title || ghostPost.title}</title>
-                <meta name="description" content={ghostPost.meta_description || ghostPost.excerpt} />
+                <meta name="description" content={ghostPost.meta_description || ""} />
                 <link rel="canonical" href={canonical} />
 
                 <meta property="og:site_name" content={settings.title} />
@@ -77,8 +77,7 @@ const ArticleMetaGhost = ({ data, settings, canonical }) => {
                 <meta property="og:description"
                     content={
                         ghostPost.og_description ||
-                        ghostPost.excerpt ||
-                        ghostPost.meta_description
+                        ghostPost.meta_description || ""
                     }
                 />
                 <meta property="og:url" content={canonical} />
@@ -97,8 +96,7 @@ const ArticleMetaGhost = ({ data, settings, canonical }) => {
                 <meta name="twitter:description"
                     content={
                         ghostPost.twitter_description ||
-                        ghostPost.excerpt ||
-                        ghostPost.meta_description
+                        ghostPost.meta_description || ""
                     }
                 />
                 <meta name="twitter:url" content={canonical} />

--- a/src/components/common/meta/AuthorMeta.js
+++ b/src/components/common/meta/AuthorMeta.js
@@ -14,7 +14,7 @@ const AuthorMeta = ({ data, settings, canonical }) => {
     const author = getAuthorProperties(data)
     const shareImage = author.image || _.get(settings, `cover_image`, null)
     const title = `${data.name} - ${settings.title}`
-    const description = data.bio || config.siteDescriptionMeta || settings.description
+    const description = data.bio || ""
 
     const jsonLd = {
         "@context": `https://schema.org/`,

--- a/src/components/common/meta/MetaData.js
+++ b/src/components/common/meta/MetaData.js
@@ -57,7 +57,7 @@ const MetaData = ({
         )
     } else {
         title = title || config.siteTitleMeta || settings.title
-        description = description || config.siteDescriptionMeta || settings.description
+        description = description || ""
         image = image || settings.cover_image || null
 
         image = image ? url.resolve(config.siteUrl, image) : null

--- a/src/components/common/meta/WebsiteMeta.js
+++ b/src/components/common/meta/WebsiteMeta.js
@@ -16,8 +16,8 @@ const WebsiteMeta = ({ data, settings, canonical, title, description, image, typ
 
     shareImage = shareImage ? url.resolve(config.siteUrl, shareImage) : null
 
-    description = description || data.meta_description || data.description || config.siteDescriptionMeta || settings.description
-    title = `${title || data.meta_title || data.name || data.title} - ${settings.title}`
+    description = description || data.meta_description || data.description || ""
+    title = title || data.meta_title || data.name || data.title || settings.title
 
     const jsonLd = {
         "@context": `https://schema.org/`,

--- a/src/templates/index.js
+++ b/src/templates/index.js
@@ -123,7 +123,11 @@ const Index = ({ data, location }) => {
                         <canvas className="Index__cursor Index__cursor--canvas"></canvas>
                     </>
                 }
-                <MetaData location={location}/>
+                <MetaData
+                    data={data}
+                    location={location}
+                    type="website"
+                />
                 <Layout isHome={true}>
                     <div className="container">
                         <div>
@@ -167,6 +171,9 @@ export default Index
 // The `limit` and `skip` values are used for pagination
 export const pageQuery = graphql`
   query GhostIndexQuery {
+    ghostPage(slug: { eq: "home" }) {
+            ...GhostPageFields
+    }
     allGhostPost(filter: {tags: {elemMatch: {name: {in: ["#HomePage", "#HomePagePartners"]}}}}) {
         nodes {
             title

--- a/src/templates/page-about.js
+++ b/src/templates/page-about.js
@@ -32,7 +32,11 @@ const PageAbout = ({ data, location, pageContext }) => {
 
     return (
         <>
-            <MetaData location={location} />
+            <MetaData
+                data={data}
+                location={location}
+                type="website"
+            />
             <Layout>
                 <div className="container">
                     <h1 className="PageAbout__h1">{page.title}</h1>
@@ -47,7 +51,7 @@ const PageAbout = ({ data, location, pageContext }) => {
                         </div>
                     </>
                     }
-                    {page.title === `Guiding Principles` && <>
+                    {page.title === `DSNP Guiding Principles` && <>
                         <div id="governance" className="PageAbout__fullHeightSection">
                             <Ethos ethosCards={ethosPosts} />
                         </div>

--- a/src/templates/page-blog.js
+++ b/src/templates/page-blog.js
@@ -15,13 +15,18 @@ import { MetaData } from '../components/common/meta'
  */
 const PageBlog = ({ data, location, pageContext }) => {
     const posts = data.allGhostPost.edges
+    const page = data.ghostPage
 
     return (
         <>
-            <MetaData location={location} />
+            <MetaData
+                data={data}
+                location={location}
+                type="website"
+            />
             <Layout>
                 <div className="container">
-                    <h1 className="content-title" data-aos="fade-right" data-aos-duration="1400">Blog</h1>
+                    <h1 className="content-title" data-aos="fade-right" data-aos-duration="1400">{page.title}</h1>
                     <section className="post-feed">
                         {posts.map(({ node }) => (
                             <PostCard key={node.id} post={node} />
@@ -50,6 +55,9 @@ export default PageBlog
 // The `limit` and `skip` values are used for pagination
 export const pageQuery = graphql`
   query GhostBlogQuery($limit: Int, $skip: Int) {
+    ghostPage(slug: { eq: "blog" }) {
+            ...GhostPageFields
+    }
     allGhostPost(
         sort: { order: DESC, fields: [published_at] },
         limit: $limit,

--- a/src/templates/page-faq.js
+++ b/src/templates/page-faq.js
@@ -18,7 +18,11 @@ const PageFaq = ({ data, location, pageContext }) => {
 
     return (
         <>
-            <MetaData location={location} />
+            <MetaData
+                data={data}
+                location={location}
+                type="website"
+            />
             <Layout>
                 <div className="container">
                     <h1 className="content-title" data-aos="fade-right" data-aos-duration="1400">{page.title}</h1>

--- a/src/utils/siteConfig.js
+++ b/src/utils/siteConfig.js
@@ -4,7 +4,7 @@ module.exports = {
     postsPerPage: 12, // Number of posts shown on paginated pages (changes this requires sometimes to delete the cache)
 
     siteTitleMeta: `DSNP.org`, // This allows an alternative site title for meta data for pages.
-    siteDescriptionMeta: `DSNP.org is a non-profit organization supporting the Decentralized Social Network Protocol (DSNP)`, // This allows an alternative site description for meta data for pages.
+    siteDescriptionMeta: ``, // This allows an alternative site description for meta data for pages, with a blank description as default for SEO.
 
     shareImageWidth: 1000, // Change to the width of your default share image
     shareImageHeight: 523, // Change to the height of your default share image


### PR DESCRIPTION
SEO changes: consistently use meta data and page title from Ghost. Meta description should default to blank.